### PR TITLE
Adapt for QuickCheck CI

### DIFF
--- a/.eqc_ci
+++ b/.eqc_ci
@@ -1,5 +1,3 @@
 %-*-Erlang-*-
 {build, "make eqc-compile"}.
-{test_path, "test"}.
-{deps, "ebin"}.
-{test_root, "."}.
+{test_path, "ebin"}.

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,9 @@ test: all
 	$(REBAR) skip_deps=true eunit
 
 eqc-compile:
-	(cd test; erl -DEQC -DTEST -eval 'make:all([{parse_transform, eqc_cover}])' -s init stop)
-	(cd src; erl -DEQC -DTEST -eval 'make:all([{parse_transform, eqc_cover}, {i, "../include"}])' -s init stop)
+	mkdir ebin
+	(cd test; erl -noshell -DEQC -DTEST -eval 'make:all([{parse_transform, eqc_cover}, {outdir, "../ebin"}])' -s init stop)
+	(cd src; erl -noshell -DEQC -DTEST -eval 'make:all([{parse_transform, eqc_cover}, {i, "../include"}, {outdir, "../ebin"}])' -s init stop)
 
 bench: all
 	-rm -r .eunit


### PR DESCRIPTION
It might be easier to write all beam-files to ebin. Also there is a
sparsly documented 'feature' of command line erl. Sometimes it reads
SIG_INTERRUPT when not wanted, use -noshell to prevent this.

Cleanup .eqc_ci
