### PR TITLE
Remove string parsing

### DIFF
--- a/c_src/bin_nif.c
+++ b/c_src/bin_nif.c
@@ -79,9 +79,6 @@ from_list(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
       d = dec_from_int64(int_v);
     else if (enif_get_double(env, cell, &float_v))
       d = dec_from_double(float_v);
-    else if (enif_inspect_binary(env, cell, &bin_v) ||
-             enif_inspect_iolist_as_binary(env, cell, &bin_v))
-      d = dec_from_binary(bin_v.size, bin_v.data);
     else
       return enif_make_badarg(env);
     target[i] = dec_serialize(d);

--- a/c_src/dec_conv.c
+++ b/c_src/dec_conv.c
@@ -113,39 +113,6 @@ dec_from_double(double v) {
   return d;
 }
 
-decimal
-dec_from_binary(int len, char* v) {
-  decimal d = {.exponent = 0, .coefficient = 0, .confidence = CERTAIN};
-  char seen_point = 0;
-  char digits = 0;
-  char c, x;
-
-  for (int i = 0; i < len; i++) {
-    c = v[i];
-    if ((i == 0) && (c == '-' || c == '+'))
-      continue;
-    else if (c >= '0' && c <= '9') {
-      x = c - '0';
-      digits += 1;
-    }
-    else if (!seen_point && (c == '.'))
-      seen_point = 1;
-    // TODO: add scientific notataion support
-    // TODO: report error on invalid character
-
-    // TODO: keep extra precision if integer oveflows coefficient,
-    //       but still falls into integer boundries
-    if (digits <= COEFFICIENT_DIGITS) {
-      d.coefficient = d.coefficient * 10 + x;
-      if (seen_point)
-        d.exponent -= 1;
-    }
-    else if (!seen_point)
-      d.exponent += 1;
-  }
-  return d;
-}
-
 int64_t dec_to_int64(decimal v) {
   return v.coefficient * qpow10(v.exponent);
 }


### PR DESCRIPTION
This removes the string parsing function dec_from_binary. String parsing really does not belong here, this library is about numbers not string representations.