### PR TITLE
Fix derivate transformation output alignment

### DIFF
--- a/c_src/trans_nif.c
+++ b/c_src/trans_nif.c
@@ -86,17 +86,20 @@ derivate(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
   GET_BIN(0, bin, count, vs);
 
-  if (count < 1) // can't be empty
-    return enif_make_badarg(env);
-
   if (! (target = (decimal*) enif_make_new_binary(env, count * sizeof(decimal), &r)))
     return enif_make_badarg(env); // TODO return propper error
 
-  if (count > 0)
+  if (count == 0)
+    return r;
+  if (count == 1) {
     target[0] = (decimal) {.coefficient = 0, .exponent = 0, .confidence = 0};
+    return r;
+  }
   for (int i = 1; i < count; i++) {
     target[i] = dec_sub(vs[i], vs[i-1]);
   }
+  target[0] = target[1];
+  target[0].confidence = 0;
   return r;
 }
 

--- a/c_src/trans_nif.c
+++ b/c_src/trans_nif.c
@@ -89,11 +89,13 @@ derivate(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
   if (count < 1) // can't be empty
     return enif_make_badarg(env);
 
-  if (! (target = (decimal*) enif_make_new_binary(env, (count - 1) * sizeof(decimal), &r)))
+  if (! (target = (decimal*) enif_make_new_binary(env, count * sizeof(decimal), &r)))
     return enif_make_badarg(env); // TODO return propper error
 
+  if (count > 0)
+    target[0] = (decimal) {.coefficient = 0, .exponent = 0, .confidence = 0};
   for (int i = 1; i < count; i++) {
-    target[i - 1] = dec_sub(vs[i], vs[i-1]);
+    target[i] = dec_sub(vs[i], vs[i-1]);
   }
   return r;
 }

--- a/eqc/mmath_trans_eqc.erl
+++ b/eqc/mmath_trans_eqc.erl
@@ -242,9 +242,10 @@ derivate(H, [{true, H1} | T], Acc) ->
 derivate(H, [{false, _} | T], Acc) ->
     derivate(H, T, [0 | Acc]);
 derivate(_, [], Acc) ->
-    L = lists:reverse(Acc),
-    [0 | L].
-
+    case lists:reverse(Acc) of
+        [] -> [0];
+        L -> [hd(L) | L]
+    end.
 
 find_first([]) ->
     0;

--- a/eqc/mmath_trans_eqc.erl
+++ b/eqc/mmath_trans_eqc.erl
@@ -24,7 +24,7 @@ prop_der() ->
 
 prop_der_len_undefined() ->
     ?FORALL(L, non_neg_int(),
-            erlang:max(0, L - 1) == len_r(mmath_trans:derivate(empty_r(L)))).
+            erlang:max(0, L) == len_r(mmath_trans:derivate(empty_r(L)))).
 
 prop_mul() ->
     ?FORALL({{L0, _, B}, S}, {defined_number_array(), int()},
@@ -242,7 +242,8 @@ derivate(H, [{true, H1} | T], Acc) ->
 derivate(H, [{false, _} | T], Acc) ->
     derivate(H, T, [0 | Acc]);
 derivate(_, [], Acc) ->
-    lists:reverse(Acc).
+    L = lists:reverse(Acc),
+    [0 | L].
 
 
 find_first([]) ->


### PR DESCRIPTION
I shifted output, so result is aligned with second of 2 values considered. Otherwise we end up with visual shift, which get deepened by derivative. It also makes mathematical sense.

I think that picture is worth a lot of words, so I drop some to explain

Before:
<img width="906" alt="screen shot 2016-05-12 at 13 48 34" src="https://cloud.githubusercontent.com/assets/646954/15224771/1f02e33c-1873-11e6-9aef-673d9135dc09.png">

After:
<img width="879" alt="screen shot 2016-05-12 at 15 10 18" src="https://cloud.githubusercontent.com/assets/646954/15224783/2c442056-1873-11e6-98d9-29752c467104.png">

This has nice side effect, that output is the same length.