### PR TITLE
Replace __USE_BSD with __USE_MISC

### DIFF
--- a/c_src/mmath.h
+++ b/c_src/mmath.h
@@ -4,7 +4,6 @@
 #  else
 #    define __USE_BSD
 #  endif
-#  define __USE_BSD
 #  include <stdint.h>
 #  include <endian.h>
 #  define htonll(v) htobe64(v)

--- a/c_src/mmath.h
+++ b/c_src/mmath.h
@@ -1,4 +1,9 @@
 #if defined(__linux__)
+#  if __GLIBC__ >= 2 && __GLIBC_MINOR__ > 19
+#    define __USE_MISC
+#  else
+#    define __USE_BSD
+#  endif
 #  define __USE_BSD
 #  include <stdint.h>
 #  include <endian.h>


### PR DESCRIPTION
As per https://lwn.net/Articles/590381/ __USE_BSD has been replaced with
__USE_MISC and deprecated. On Ubuntu Xenial systems (glibc 2..23) it appears that __USE_BSD
doesn't work at all anymore.

Fixes #29