### PR TITLE
Fuck linux

### DIFF
--- a/c_src/mmath.h
+++ b/c_src/mmath.h
@@ -1,9 +1,23 @@
 #if defined(__linux__)
+
+// FUCK LINUX!
+
 #  define __USE_BSD
 #  include <stdint.h>
 #  include <endian.h>
-#  define htonll(v) htobe64(v)
-#  define ntohll(v) be64toh(v)
+
+#if __BYTE_ORDER == __BIG_ENDIAN
+
+#define htonll(x) ((uint64_t) x)
+#define ntohll(x) ((uint64_t) x)
+
+#else
+
+#define htonll(x) ((((uint64_t)htonl(x)) << 32) + htonl(x >> 32));
+#define ntohll(x) ((((uint64_t)ntohl(x)) << 32) + ntohl(x >> 32));
+
+#endif // __BYTE_ORDER == __BIG_ENDIAN
+
 /* On modern Os X'es (>= 10.10) htonll is defined in machine/endian.h, but on older it is missing */
 #elif defined(__APPLE__) && !defined(htonll)
 #  include <libkern/OSByteOrder.h>

--- a/c_src/mmath.h
+++ b/c_src/mmath.h
@@ -2,9 +2,7 @@
 
 // FUCK LINUX!
 
-#  define __USE_BSD
 #  include <stdint.h>
-#  include <endian.h>
 
 #if __BYTE_ORDER == __BIG_ENDIAN
 
@@ -13,8 +11,9 @@
 
 #else
 
-#define htonll(x) ((((uint64_t)htonl(x)) << 32) + htonl(x >> 32));
-#define ntohll(x) ((((uint64_t)ntohl(x)) << 32) + ntohl(x >> 32));
+#  include <arpa/inet.h>
+#define htonll(x) ((((uint64_t)htonl(x)) << 32) + htonl(x >> 32))
+#define ntohll(x) ((((uint64_t)ntohl(x)) << 32) + ntohl(x >> 32))
 
 #endif // __BYTE_ORDER == __BIG_ENDIAN
 

--- a/c_src/mmath.h
+++ b/c_src/mmath.h
@@ -3,6 +3,7 @@
 // FUCK LINUX!
 
 #  include <stdint.h>
+#  include <sys/param.h>
 
 #if __BYTE_ORDER == __BIG_ENDIAN
 


### PR DESCRIPTION
This implements a own version of htonll (and ntohll) since linux can't be bothered to provide those or consistant htobe64 and be64toh. Pretty sure this is the 10000000th time someone implemented tome for linux .....

They might also work, any of you poor sods stuck at linux feel like trying out if they do what they're supposed to do before I blindly merge them?

resolved #29 