### PR TITLE
Dev replace below confidence

### DIFF
--- a/c_src/trans_nif.c
+++ b/c_src/trans_nif.c
@@ -113,8 +113,8 @@ confidence(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
   return r;
 }
 
-/* Given series, confidence level and default value reset everything below
-   with the given default value.
+/* Given series, confidence level and default value reset everything
+   equal to or below with the given default value.
  */
 static ERL_NIF_TERM
 replace_below_confidence(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
@@ -149,7 +149,7 @@ replace_below_confidence(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
   if (! (target = (ffloat*) enif_make_new_binary(env, count * sizeof(ffloat), &r)))
     return enif_make_badarg(env); // TODO return propper error
   for (int i = 0; i < count; i++) {
-    if (vs[i].confidence >= threshold_confidence) {
+    if (vs[i].confidence > threshold_confidence) {
       target[i] = (ffloat){
         .value = vs[i].value,
         .confidence = vs[i].confidence

--- a/c_src/trans_nif.c
+++ b/c_src/trans_nif.c
@@ -113,6 +113,57 @@ confidence(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
   return r;
 }
 
+/* Given series, confidence level and default value reset everything below
+   with the given default value.
+ */
+static ERL_NIF_TERM
+replace_below_confidence(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+  ErlNifBinary a;
+  ERL_NIF_TERM r;
+  ffloat* vs;
+  ErlNifSInt64 int_v;
+  double threshold_confidence;
+  ErlNifSInt64 int_default;
+  double default_value;
+  ffloat* target;
+  int count;
+
+  if (argc != 3)
+    return enif_make_badarg(env);
+
+  GET_BIN(0, a, count, vs);
+
+  if (enif_get_int64(env, argv[1], &int_v)) {
+    threshold_confidence = (double) int_v;
+  } else if (!enif_get_double(env, argv[1], &threshold_confidence)) {
+    return enif_make_badarg(env);
+  }
+
+  if (enif_get_int64(env, argv[2], &int_default)) {
+    default_value = (double) int_default;
+  } else if (!enif_get_double(env, argv[2], &default_value)) {
+    return enif_make_badarg(env);
+  }
+
+  if (! (target = (ffloat*) enif_make_new_binary(env, count * sizeof(ffloat), &r)))
+    return enif_make_badarg(env); // TODO return propper error
+  for (int i = 0; i < count; i++) {
+    if (vs[i].confidence >= threshold_confidence) {
+      target[i] = (ffloat){
+        .value = vs[i].value,
+        .confidence = vs[i].confidence
+      };
+    } else {
+      target[i] = (ffloat){
+        .value = default_value,
+	.confidence = vs[i].confidence
+      };
+    }
+  }
+  return r;
+}
+
 static ERL_NIF_TERM
 square_root(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -221,6 +272,7 @@ static ErlNifFunc nif_funcs[] = {
   {"divide",      2, divide},
   {"derivate",    1, derivate},
   {"confidence",  1, confidence},
+  {"replace_below_confidence",  3, replace_below_confidence},
   {"sqrt_scale",  1, square_root},
   {"log10_scale", 1, c_log10},
   {"abs",         1, c_abs}

--- a/src/mmath_trans.erl
+++ b/src/mmath_trans.erl
@@ -8,6 +8,10 @@
 %%%-------------------------------------------------------------------
 -module(mmath_trans).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -export([
          derivate/1,
          confidence/1,
@@ -160,3 +164,38 @@ min(_M, _D) ->
 -spec max(binary(), number()) -> binary().
 max(_M, _D) ->
     erlang:nif_error(nif_library_not_loaded).
+
+-ifdef(TEST).
+
+%% first 8 octets is float serialized value
+%% last 8 octets is float serialized confidence
+-define(EMPTY, <<0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0>>).
+
+unconvert_h(X) ->
+    mmath_bin:to_list(mmath_bin:derealize(X)).
+
+convert_h(X) ->
+    mmath_bin:realize(mmath_bin:from_list(X)).
+
+replace_below_confidence_test() ->
+    ?assertEqual([1.0],
+                 unconvert_h(
+                   mmath_trans:replace_below_confidence(
+                     ?EMPTY, 0.9, 1.0))),
+    ?assertEqual([0.124, 2.0],
+                 unconvert_h(
+                   mmath_trans:replace_below_confidence(
+                     iolist_to_binary([?EMPTY, convert_h([2.0])]),
+                     0.9, 0.124))),
+    ?assertEqual([0.124, 0.122, 2.0, 0.124],
+                 unconvert_h(
+                   mmath_trans:replace_below_confidence(
+                     iolist_to_binary([?EMPTY, convert_h([0.122, 2.0]), ?EMPTY]),
+                     0.9, 0.124))),
+    ?assertEqual([0.124, 0.122, 2.0, 0.124, 14.09],
+                 unconvert_h(
+                   mmath_trans:replace_below_confidence(
+                     iolist_to_binary([?EMPTY, convert_h([0.122, 2.0]), ?EMPTY,
+                                      convert_h([14.09])]),
+                     0.9, 0.124))).
+-endif.

--- a/src/mmath_trans.erl
+++ b/src/mmath_trans.erl
@@ -11,6 +11,7 @@
 -export([
          derivate/1,
          confidence/1,
+         replace_below_confidence/3,
          mul/2,
          divide/2,
          add/2,
@@ -100,6 +101,17 @@ derivate(_) ->
 %%--------------------------------------------------------------------
 -spec confidence(binary()) -> binary().
 confidence(_) ->
+    erlang:nif_error(nif_library_not_loaded).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Transforms the series such that values with confidence lower
+%% than or equal to the threshold will be reset to the given default
+%% value.
+%% @end
+%%--------------------------------------------------------------------
+-spec replace_below_confidence(binary(), number(), number()) -> binary().
+replace_below_confidence(_, _Threshold, _Default) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
 replace_below_confidence when lower confidence

The intent is to reset data to some default value when
the confidence level is equal to or below certain value.

Sample usage:

```
    replace_below_confidence($interval, 0.5, 0.0)
```

In the above case 0.5 is the threshold confidence level,
equal to or below which the metric value will be reset to 0.0 (3rd
argument).

@see dalmatinerdb/dalmatinerdb#134